### PR TITLE
Make primary variant color non-white

### DIFF
--- a/src/components/mdc/_theme.scss
+++ b/src/components/mdc/_theme.scss
@@ -4,7 +4,7 @@
 
 :root {
   --mdc-theme-primary: #005CB9;
-  --mdc-theme-primary-variant: #fff;
+  --mdc-theme-primary-variant: #5885b3;
   --mdc-theme-secondary: #103066;
   --mdc-theme-error: #C30000;
   --progress-bar-color: #005CB9;


### PR DESCRIPTION
### Fixed
- Make primary variant color non-white (so TextField floating labels don't "disappear")