### PR TITLE
Go back to household / settings after removing a dependent

### DIFF
--- a/src/pages/household/settings/dependent/[uuid].svelte
+++ b/src/pages/household/settings/dependent/[uuid].svelte
@@ -19,6 +19,7 @@ const onCancel = () => {
 const onRemove = event => {
   const dependentUuid = event.detail
   console.log('Remove', dependentUuid)
+  $goto('../../settings')
 }
 const onSubmit = event => {
   const formData = event.detail


### PR DESCRIPTION
### Fixed
- Go back to household / settings after removing a dependent