### PR TITLE
Update the new-item form

### DIFF
--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -31,7 +31,7 @@ $: menuItems = [
   //   label: 'Chat',
   // },
   {
-    url: '/item',
+    url: '/items/new',
     icon: 'add_circle',
     label: 'Add Item',
     button: true,

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -7,7 +7,6 @@ let formData = {
   categoryUuid: '',
   shortName: '',
   itemDescription: '',
-  riskCategory: '',
   uniqueIdentifier: '',
   make: '',
   model: '',
@@ -24,17 +23,6 @@ let categoryOptions = [
   {
     "name": "Cell Phone",
     "id": "22222222-2222-4222-2222-222222222222",
-  },
-]
-
-const riskCategoryOptions = [
-  {
-    label: 'Carried with me',
-    value: 'mobile',
-  },
-  {
-    label: 'In one place (home or office)',
-    value: 'stationary',
   },
 ]
 
@@ -81,8 +69,6 @@ const saveForLater = () => {
       <TextArea label="Item description" bind:value={formData.itemDescription} rows="4"></TextArea>
       <Description>For personal use.</Description>
     </p>
-    <p>This item primarily stays:</p>
-    <RadioOptions name="riskCategory" options={riskCategoryOptions} bind:value={formData.riskCategory} />
     <p>
       <TextField label="Unique identifier" bind:value={formData.uniqueIdentifier}></TextField>
       <Description>Optional. Serial number, IMEI, service tag, VIN</Description>

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -11,7 +11,7 @@ let formData = {
   make: '',
   model: '',
   accountablePersonUuid: '',
-  itemCostUSD: '',
+  marketValueUSD: '',
 }
 
 /* @todo Pull this from the database eventually: */
@@ -90,7 +90,7 @@ const saveForLater = () => {
       </Description>
     </p>
     <p>
-      <TextField label="Item cost (USD)" bind:value={formData.itemCostUSD}></TextField>
+      <TextField label="Market value (USD)" bind:value={formData.marketValueUSD}></TextField>
       <Description>
         To convert to USD, use 
         <a href="https://www.google.com/search?q=currency+converter" target="_blank">this converter</a>.

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -1,5 +1,5 @@
 <script>
-import { Breadcrumb, Description } from '../../components'
+import { Breadcrumb, Description, MoneyInput } from '../../components'
 import { goto } from '@roxi/routify'
 import { Button, Form, Page, Select, TextArea, TextField } from '@silintl/ui-components'
 
@@ -90,7 +90,7 @@ const saveForLater = () => {
       </Description>
     </p>
     <p>
-      <TextField label="Market value (USD)" bind:value={formData.marketValueUSD}></TextField>
+      <MoneyInput label="Market value (USD)" bind:value={formData.marketValueUSD} />
       <Description>
         To convert to USD, use 
         <a href="https://www.google.com/search?q=currency+converter" target="_blank">this converter</a>.

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -4,6 +4,7 @@ import { goto } from '@roxi/routify'
 import { Button, Form, Page, Select, TextArea, TextField } from '@silintl/ui-components'
 
 let formData = {
+  categoryUuid: '',
   shortName: '',
   itemDescription: '',
   riskCategory: '',
@@ -13,6 +14,19 @@ let formData = {
   accountablePersonUuid: '',
   itemCostUSD: '',
 }
+
+/* @todo Pull this from the database eventually: */
+let categoryOptions = [
+  {
+    "name": "Musical Instrument",
+    "id": "11111111-1111-4111-1111-111111111111",
+  },
+  {
+    "name": "Cell Phone",
+    "id": "22222222-2222-4222-2222-222222222222",
+  },
+]
+
 const riskCategoryOptions = [
   {
     label: 'Carried with me',
@@ -56,6 +70,9 @@ const saveForLater = () => {
 <Page>
   <Breadcrumb />
   <Form on:submit={onSubmit}>
+    <p>
+      <Select label="Category" bind:selectedID={formData.categoryUuid} options={categoryOptions} />
+    </p>
     <p>
       <TextField label="Short name" bind:value={formData.shortName}></TextField>
       <Description>This label will appear on your statements.</Description>

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -1,5 +1,5 @@
 <script>
-import { Breadcrumb, Description, RadioOptions } from '../../components'
+import { Breadcrumb, Description } from '../../components'
 import { goto } from '@roxi/routify'
 import { Button, Form, Page, Select, TextArea, TextField } from '@silintl/ui-components'
 


### PR DESCRIPTION
### Fixed
- Fix menu link to "New item" form
- Add back in the UI (dropdown) for a new item's category
- Remove "Risk category" from UI, since that will come from Category
- Rename "Item cost" to "Market value" on new-item form
- Switch new-item form's "Market value" field to use MoneyInput