### PR TITLE
Menu bugfixes

### DIFF
--- a/src/components/AppHeader.svelte
+++ b/src/components/AppHeader.svelte
@@ -61,7 +61,6 @@ header {
       {/if}
     </button>
 
-    <!-- TODO set menuOpen to false when menu closes -->
     <Menu autofocus bind:menuOpen {menuItems} on:syncToggler={() => menuOpen = false}/>
   </div>
 </header>

--- a/src/components/AppHeader.svelte
+++ b/src/components/AppHeader.svelte
@@ -18,7 +18,7 @@ const menuItems = [
 let showImage = true
 let alt = 'avatar'
 let showDrawerButton
-let menuToggler = false
+let menuOpen = false
 
 const dispatch = createEventDispatcher()
 
@@ -28,7 +28,7 @@ $: ownerInitial = $user.first_name?.charAt(0) || ''
 onMount(() => showOrHideDrawerButton())
 
 const avatarError = () => showImage = false
-const toggleMenu = () => menuToggler = !menuToggler
+const toggleMenu = () => menuOpen = !menuOpen
 const showOrHideDrawerButton = () => isAboveTablet() ? (showDrawerButton = false) : (showDrawerButton = true)
 const toggleDrawerHandler = () => dispatch('toggleDrawer') //TODO toggle drawer
 </script>
@@ -61,8 +61,8 @@ header {
       {/if}
     </button>
 
-    <!-- TODO set menuToggler to false when menu closes -->
-    <Menu autofocus bind:menuToggler {menuItems} on:syncToggler={() => menuToggler = false}/>
+    <!-- TODO set menuOpen to false when menu closes -->
+    <Menu autofocus bind:menuOpen {menuItems} on:syncToggler={() => menuOpen = false}/>
   </div>
 </header>
 

--- a/src/components/mdc/Menu/Menu.svelte
+++ b/src/components/mdc/Menu/Menu.svelte
@@ -41,21 +41,17 @@ const onMenuClose = () => !menu.open && (menuToggler = false)
 <div class="mdc-menu mdc-menu-surface" bind:this={element}>
   <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
     {#each menuItems as {icon, label, url}, i}
-      <li on:click={() => handleItemClick(url)} class="mdc-list-item" role="menuitem" on:blur={onMenuClose}>
+      <!-- svelte-ignore a11y-invalid-attribute -->
+      <a on:click={() => handleItemClick(url)} role="menuitem" class="mdc-list-item" class:mdc-list-item--activated={isMenuItemActive(currentUrl, url)} href=""
+        aria-current={isMenuItemActive(currentUrl, url) ? "page" : null} tabindex={i === 0 ? 0 : undefined} on:blur={onMenuClose}>
         <span class="mdc-list-item__ripple"></span>
-        {#if url}
-          <!-- svelte-ignore a11y-invalid-attribute -->
-          <a class="mdc-list-item" class:mdc-list-item--activated={isMenuItemActive(currentUrl, url)} href=""
-            aria-current={isMenuItemActive(currentUrl, url) ? "page" : null} tabindex={i === 0 ? 0 : undefined} on:blur={onMenuClose}>
-            {#if icon}
-              <i class="material-icons mdc-list-item__graphic" aria-hidden="true">{icon}</i>
-            {/if}
-            {#if label}
-              <span class="mdc-list-item__text">{label}</span>
-            {/if}
-          </a>
+        {#if icon}
+          <i class="material-icons mdc-list-item__graphic" aria-hidden="true">{icon}</i>
         {/if}
-      </li>
+        {#if label}
+          <span class="mdc-list-item__text">{label}</span>
+        {/if}
+      </a>
     {/each}
   </ul>
 </div>

--- a/src/components/mdc/Menu/Menu.svelte
+++ b/src/components/mdc/Menu/Menu.svelte
@@ -6,7 +6,7 @@ import { createEventDispatcher } from 'svelte'
 import { goto } from '@roxi/routify';
 
 export let menuItems = []
-export let menuToggler = false
+export let menuOpen = false
 
 let menu = {}
 let element = {}
@@ -14,7 +14,7 @@ let element = {}
 const dispatch = createEventDispatcher()
 
 $: currentUrl = window.location.pathname
-$: menu.open = menuToggler
+$: menu.open = menuOpen
 
 onMount(() => {
   menu = new MDCMenu(element)
@@ -35,16 +35,21 @@ const handleItemClick = url => {
   }
 }
 const handleItemKeydown = (e, url) => (e.code == 'Space' || e.code == 'Enter') && handleItemClick(url)
-const onMenuClose = () => !menu.open && (menuToggler = false)
+const closeMenuHandler = () => {
+  if (!menu.open) { //checks to make sure the click wasn't opening the menu or on the menu
+    menuOpen = false
+  }
+}
 </script>
-<svelte:body on:click={onMenuClose} />
+<!-- mdc-menu doesn't have a method to let us know when it closes so this listens for clicks -->
+<svelte:body on:click={closeMenuHandler} />
 
 <div class="mdc-menu mdc-menu-surface" bind:this={element}>
   <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
     {#each menuItems as {icon, label, url}, i}
       <!-- svelte-ignore a11y-invalid-attribute -->
       <a on:click|preventDefault={() => handleItemClick(url)} on:keydown|preventDefault={ e => handleItemKeydown(e, url)} role="menuitem" class="mdc-list-item" class:mdc-list-item--activated={isMenuItemActive(currentUrl, url)} href=""
-        aria-current={isMenuItemActive(currentUrl, url) ? "page" : null} tabindex={i === 0 ? 0 : undefined} on:blur={onMenuClose}>
+        aria-current={isMenuItemActive(currentUrl, url) ? "page" : null} tabindex={i === 0 ? 0 : undefined} on:blur={closeMenuHandler}>
         <span class="mdc-list-item__ripple"></span>
         {#if icon}
           <i class="material-icons mdc-list-item__graphic" aria-hidden="true">{icon}</i>

--- a/src/components/mdc/Menu/Menu.svelte
+++ b/src/components/mdc/Menu/Menu.svelte
@@ -48,7 +48,7 @@ const closeMenuHandler = () => {
   <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
     {#each menuItems as {icon, label, url}, i}
       <!-- svelte-ignore a11y-invalid-attribute -->
-      <a on:click|preventDefault={() => handleItemClick(url)} on:keydown|preventDefault={ e => handleItemKeydown(e, url)} role="menuitem" class="mdc-list-item" class:mdc-list-item--activated={isMenuItemActive(currentUrl, url)} href=""
+      <li on:click|preventDefault={() => handleItemClick(url)} on:keydown|preventDefault={ e => handleItemKeydown(e, url)} role="menuitem" class="mdc-list-item" class:mdc-list-item--activated={isMenuItemActive(currentUrl, url)}
         aria-current={isMenuItemActive(currentUrl, url) ? "page" : null} tabindex={i === 0 ? 0 : undefined} on:blur={closeMenuHandler}>
         <span class="mdc-list-item__ripple"></span>
         {#if icon}
@@ -57,7 +57,7 @@ const closeMenuHandler = () => {
         {#if label}
           <span class="mdc-list-item__text">{label}</span>
         {/if}
-      </a>
+      </li>
     {/each}
   </ul>
 </div>

--- a/src/components/mdc/Menu/Menu.svelte
+++ b/src/components/mdc/Menu/Menu.svelte
@@ -34,6 +34,7 @@ const handleItemClick = url => {
     $goto(url)
   }
 }
+const handleItemKeydown = (e, url) => (e.code == 'Space' || e.code == 'Enter') && handleItemClick(url)
 const onMenuClose = () => !menu.open && (menuToggler = false)
 </script>
 <svelte:body on:click={onMenuClose} />
@@ -42,7 +43,7 @@ const onMenuClose = () => !menu.open && (menuToggler = false)
   <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
     {#each menuItems as {icon, label, url}, i}
       <!-- svelte-ignore a11y-invalid-attribute -->
-      <a on:click={() => handleItemClick(url)} role="menuitem" class="mdc-list-item" class:mdc-list-item--activated={isMenuItemActive(currentUrl, url)} href=""
+      <a on:click|preventDefault={() => handleItemClick(url)} on:keydown|preventDefault={ e => handleItemKeydown(e, url)} role="menuitem" class="mdc-list-item" class:mdc-list-item--activated={isMenuItemActive(currentUrl, url)} href=""
         aria-current={isMenuItemActive(currentUrl, url) ? "page" : null} tabindex={i === 0 ? 0 : undefined} on:blur={onMenuClose}>
         <span class="mdc-list-item__ripple"></span>
         {#if icon}

--- a/src/components/mdc/Menu/Menu.svelte
+++ b/src/components/mdc/Menu/Menu.svelte
@@ -1,3 +1,4 @@
+<!-- https://github.com/material-components/material-components-web/tree/master/packages/mdc-menu -->
 <script>
 import { onDestroy, onMount } from 'svelte'
 import { MDCMenu } from '@material/menu'
@@ -33,17 +34,19 @@ const handleItemClick = url => {
     $goto(url)
   }
 }
+const onMenuClose = () => !menu.open && (menuToggler = false)
 </script>
+<svelte:body on:click={onMenuClose} />
 
 <div class="mdc-menu mdc-menu-surface" bind:this={element}>
   <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
     {#each menuItems as {icon, label, url}, i}
-      <li on:click={() => handleItemClick(url)} class="mdc-list-item" role="menuitem">
+      <li on:click={() => handleItemClick(url)} class="mdc-list-item" role="menuitem" on:blur={onMenuClose}>
         <span class="mdc-list-item__ripple"></span>
         {#if url}
           <!-- svelte-ignore a11y-invalid-attribute -->
           <a class="mdc-list-item" class:mdc-list-item--activated={isMenuItemActive(currentUrl, url)} href=""
-            aria-current={isMenuItemActive(currentUrl, url) ? "page" : null} tabindex={i === 0 ? 0 : undefined}>
+            aria-current={isMenuItemActive(currentUrl, url) ? "page" : null} tabindex={i === 0 ? 0 : undefined} on:blur={onMenuClose}>
             {#if icon}
               <i class="material-icons mdc-list-item__graphic" aria-hidden="true">{icon}</i>
             {/if}

--- a/src/pages/home.svelte
+++ b/src/pages/home.svelte
@@ -186,7 +186,7 @@ const handleMoreVertClick = id => {
                     <path fill="currentColor" d="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z" />
                   </svg>
                   <!--TODO FUTURE: make this show above the more vert icon when it is in the lower half of the page-->
-                  <div class="item-menu"><Menu bind:menuToggler={shownMenus[item.id]} menuItems="{menuItems(item.id)}" on:syncToggler={() => shownMenus[item.id] = false}/></div>
+                  <div class="item-menu"><Menu bind:menuOpen={shownMenus[item.id]} menuItems="{menuItems(item.id)}" on:syncToggler={() => shownMenus[item.id] = false}/></div>
                 </Datatable.Data.Row.Item>
               </Datatable.Data.Row>
           {/each}


### PR DESCRIPTION
## Fixed:

- bug requiring a second click to open menu
- bug causing an extra focusable mdc-list-item

### Added support for space and Enter keys to select menu items

Do we need the menu items to remain an anchor element? Seems to work fine with `<li>` but thought you and Levi mentioned something about needing it for the breadcrumbs.
