### PR TITLE
Avoid API calls with a policy id of `null`

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -7,7 +7,7 @@ import { start, stop } from "../components/progress/index.js"
  *
  * @description a function to fetch the items of a policy
  * @export
- * @param {Number} id
+ * @param {string} policyId -- The UUID for the desired policy
  * @return {Object} 
  */
 export async function getItems(policyId) {

--- a/src/pages/home.svelte
+++ b/src/pages/home.svelte
@@ -26,12 +26,14 @@ let goToItemDetails = true
 let shownMenus = {}
 let items = []
 
+$: if ($user.policy_id) {
+  getItems($user.policy_id).then(loadedItems => items = loadedItems)
+}
+
 onMount( () => {
   loadClaims()
 
   loadPolicies()
-  
-  getItems($user.policy_id).then(loadedItems => items = loadedItems)
 })
 
 const redirect = url => {

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -21,7 +21,9 @@ let householdMembers = [
   },
 ]
 
-$: loadDependents($user.policy_id)
+$: if ($user.policy_id) {
+  loadDependents($user.policy_id)
+}
 
 const edit = uuid => $goto(`/household/settings/dependent/${uuid}`)
 </script>


### PR DESCRIPTION
### Fixed
- Only try to load the items if we have a policy ID
- Don't load the list of dependents until we have a policy ID
- Fix parameter documentation for `getItems()`