### PR TITLE
Household policy members

### DIFF
--- a/src/data/policy-members.js
+++ b/src/data/policy-members.js
@@ -12,13 +12,14 @@ export const membersByPolicyId = writable({})
  * @return {Object[]} 
  */
 export async function loadMembersOfPolicy(policyId) {
-  start(policyId)
+  const urlPath = `policies/${policyId}/members`
+  start(urlPath)
 
-  const policyMembers = await GET(`policies/${policyId}/members`)
+  const policyMembers = await GET(urlPath)
   membersByPolicyId.update(data => {
     data[policyId] = policyMembers
     return data
   })
 
-  stop(policyId)
+  stop(urlPath)
 }

--- a/src/data/policy-members.js
+++ b/src/data/policy-members.js
@@ -1,5 +1,8 @@
 import { GET } from './index.js'
 import { start, stop } from '../components/progress'
+import { writable } from 'svelte/store';
+
+export const membersByPolicyId = writable({})
 
 /**
  * A function to fetch the items of a policy
@@ -8,11 +11,15 @@ import { start, stop } from '../components/progress'
  * @param {string} policyId -- The UUID for the desired policy
  * @return {Object[]} 
  */
-export async function getPolicyMembers(policyId) {
+export async function loadMembersOfPolicy(policyId) {
+  console.log('loadMembersOfPolicy(', policyId, ')')
   start(policyId)
 
   const policyMembers = await GET(`policies/${policyId}/members`)
+  membersByPolicyId.update(data => {
+    data[policyId] = policyMembers
+    return data
+  })
 
   stop(policyId)
-  return policyMembers
 }

--- a/src/data/policy-members.js
+++ b/src/data/policy-members.js
@@ -1,5 +1,4 @@
 import { GET } from './index.js'
-import { throwError } from '../error'
 import { start, stop } from '../components/progress'
 
 /**

--- a/src/data/policy-members.js
+++ b/src/data/policy-members.js
@@ -1,6 +1,6 @@
 import { GET } from './index.js'
 import { start, stop } from '../components/progress'
-import { writable } from 'svelte/store';
+import { writable } from 'svelte/store'
 
 export const membersByPolicyId = writable({})
 

--- a/src/data/policy-members.js
+++ b/src/data/policy-members.js
@@ -1,0 +1,19 @@
+import { GET } from './index.js'
+import { throwError } from '../error'
+import { start, stop } from '../components/progress'
+
+/**
+ * A function to fetch the items of a policy
+ * 
+ * @export
+ * @param {string} policyId -- The UUID for the desired policy
+ * @return {Object[]} 
+ */
+export async function getPolicyMembers(policyId) {
+  start(policyId)
+
+  const policyMembers = await GET(`policies/${policyId}/members`)
+
+  stop(policyId)
+  return policyMembers
+}

--- a/src/data/policy-members.js
+++ b/src/data/policy-members.js
@@ -12,7 +12,6 @@ export const membersByPolicyId = writable({})
  * @return {Object[]} 
  */
 export async function loadMembersOfPolicy(policyId) {
-  console.log('loadMembersOfPolicy(', policyId, ')')
   start(policyId)
 
   const policyMembers = await GET(`policies/${policyId}/members`)

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -1,31 +1,25 @@
 <script>
 import user from '../../authn/user'
 import { Breadcrumb } from "../../components"
-import { dependents, initialized, loadDependents } from '../../data/dependents'
+import { dependents, initialized as haveLoadedDependents, loadDependents } from '../../data/dependents'
+import { getPolicyMembers } from '../../data/policy-members'
 import { goto } from "@roxi/routify"
 import { Button, IconButton, Page } from "@silintl/ui-components"
 
-// TODO: make this dependent on backend
-let householdMembers = [
-  {
-    id: '11111111-1111-4111-1111-111111111111',
-    name: "Jeff Smith",
-    isYou: true,
-    email: "jeff_smith@sil.org",
-  },
-  {
-    id: '22222222-2222-4222-2222-222222222222',
-    name: "Sarah Smith",
-    isYou: false,
-    email: "sarah_smith@sil.org",
-  },
-]
+let householdMembers = []
 
-$: if ($user.policy_id && !$initialized) {
+$: if ($user.policy_id && !$haveLoadedDependents) {
   loadDependents($user.policy_id)
 }
 
+$: if ($user.policy_id) {
+  getPolicyMembers($user.policy_id).then(policyMembers => {
+    householdMembers = policyMembers
+  })
+}
+
 const edit = id => $goto(`/household/settings/dependent/${id}`)
+const isYou = householdMember => householdMember.id === $user.id
 </script>
 
 <style>
@@ -64,12 +58,12 @@ const edit = id => $goto(`/household/settings/dependent/${id}`)
 
   <h4>Household members</h4>
   <ul class="accountable-people-list">
-    {#each householdMembers as person}
+    {#each householdMembers as householdMember}
       <li class="accountable-people-list-item">
-        {person.name}
-        {person.isYou ? "(you)" : ""}
+        {householdMember.first_name} {householdMember.last_name}
+        {isYou(householdMember) ? "(you)" : ""}
         <br />
-        <small>{person.email}</small>
+        <small>{householdMember.email}</small>
       </li>
     {/each}
   </ul>

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -2,7 +2,7 @@
 import user from '../../authn/user'
 import { Breadcrumb } from "../../components"
 import { dependents, initialized as haveLoadedDependents, loadDependents } from '../../data/dependents'
-import { getPolicyMembers } from '../../data/policy-members'
+import { loadMembersOfPolicy, membersByPolicyId } from '../../data/policy-members'
 import { goto } from "@roxi/routify"
 import { Button, IconButton, Page } from "@silintl/ui-components"
 
@@ -13,9 +13,12 @@ $: if ($user.policy_id && !$haveLoadedDependents) {
 }
 
 $: if ($user.policy_id) {
-  getPolicyMembers($user.policy_id).then(policyMembers => {
-    householdMembers = policyMembers
-  })
+  loadMembersOfPolicy($user.policy_id)
+}
+
+$: haveLoadedPolicyMembers = $membersByPolicyId[$user.policy_id] !== undefined
+$: if ($user.policy_id && haveLoadedPolicyMembers) {
+  householdMembers = $membersByPolicyId[$user.policy_id]
 }
 
 const edit = id => $goto(`/household/settings/dependent/${id}`)


### PR DESCRIPTION
### Added
- Load household members from API
- Cache policy members, but refresh on each visit to household settings

---

I'm curious what you think about this "caching" strategy, @Schparky and @hobbitronics. This avoids an empty list of household members after we've loaded them the first time, but ensures the user sees current data quickly even on subsequent visits to that page. (Note that this is only caching them in memory, not across full page reloads.)