### PR TITLE
PolicyCreateItem api call

### DIFF
--- a/src/data/itemCategories.js
+++ b/src/data/itemCategories.js
@@ -1,5 +1,6 @@
 import { GET } from "."
-import { writable } from "svelte/store";
+import { writable } from "svelte/store"
+import { start, stop } from "../components/progress"
 
 export const categories = writable([])
 export const initialized = writable(false)
@@ -14,8 +15,12 @@ export async function init() {
  * @export
  */
 export async function loadCategories() {
+  start()
+
   let catz = await GET('item-categories')
 
+  stop()
+  
   categories.set(catz)
   initialized.set(true)
 }

--- a/src/data/itemCategories.js
+++ b/src/data/itemCategories.js
@@ -15,11 +15,11 @@ export async function init() {
  * @export
  */
 export async function loadCategories() {
-  start()
+  start('itemCategories')
 
   let catz = await GET('item-categories')
 
-  stop()
+  stop('itemCategories')
   
   categories.set(catz)
   initialized.set(true)

--- a/src/data/itemCategories.js
+++ b/src/data/itemCategories.js
@@ -1,6 +1,6 @@
 import { GET } from "."
-import { writable } from "svelte/store"
 import { start, stop } from "../components/progress"
+import { writable } from "svelte/store"
 
 export const categories = writable([])
 export const initialized = writable(false)

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -3,7 +3,7 @@ import { throwError } from "../error"
 import { start, stop } from "../components/progress/index.js"
 import { writable } from "svelte/store"
 
-const items = writable([])
+export const items = writable([])
 
 /**
  *

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -1,7 +1,9 @@
 import { CREATE, DELETE, GET, UPDATE } from "./index.js"
 import { throwError } from "../error"
 import { start, stop } from "../components/progress/index.js"
+import { writable } from "svelte/store"
 
+const items = writable([])
 
 /**
  *
@@ -28,27 +30,30 @@ export async function getItems(policyId) {
  * @return {Object} 
  */
 export async function addItem(policyId, itemData) {
+  start(policyId)
+
   const parsedItemData = {
-    id: "fb34d3d4-f6de-11eb-9a03-0242ac130003",
-    item_name: itemData.shortName,
-    type: itemData.category.name,
+    category_id: itemData.category.name,
     country: itemData.country,
+    coverage_amount: Number(itemData.marketValueUSD),
+    coverage_start_date: itemData.coverage_start_date,
+    coverage_status: itemData.coverage_status,
     description: itemData.itemDescription,
+    in_storage: itemData,
     make: itemData.make,
     model: itemData.model,
-    serial_number: itemData.uniqueIdentifier,
-    accountable_person: itemData.accountablePersonName,
-    coverage_amount: itemData.marketValueUSD,
-    recent_activity: "Added just now",
-    premium: itemData.marketValueUSD*0.05
+    name: itemData.shortName,
+    purchase_date: itemData.purchase_date,
+    serial_number: itemData.uniqueIdentifier
   }
 
-  // const item = await CREATE(`policies/${policyId}/items`, parsedItemData)
+  const item = await CREATE(`policies/${policyId}/items`, parsedItemData)
 
-  // TODO: change this when endpoint is done and push item
-  exampleItems.push(parsedItemData)
+  stop(policyId)
 
-  return parsedItemData
+  items.push(item)
+
+  return item
 }
 
 /**

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -33,13 +33,13 @@ export async function addItem(policyId, itemData) {
   start(policyId)
 
   const parsedItemData = {
-    category_id: itemData.category.name,
+    category_id: itemData.category,
     country: itemData.country,
     coverage_amount: Number(itemData.marketValueUSD),
     coverage_start_date: itemData.coverage_start_date,
     coverage_status: itemData.coverage_status,
     description: itemData.itemDescription,
-    in_storage: itemData,
+    in_storage: itemData.in_storage,
     make: itemData.make,
     model: itemData.model,
     name: itemData.shortName,

--- a/src/dates.js
+++ b/src/dates.js
@@ -1,0 +1,7 @@
+export const formatDate = (dateString, ...others) => {
+  if (dateString) {
+    const date = new Date(dateString)
+    return date.toLocaleDateString(...others)
+  }
+  return ''
+}

--- a/src/dates.js
+++ b/src/dates.js
@@ -1,7 +1,0 @@
-export const formatDate = (dateString, ...others) => {
-  if (dateString) {
-    const date = new Date(dateString)
-    return date.toLocaleDateString(...others)
-  }
-  return ''
-}

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -2,7 +2,7 @@
 import user from '../../authn/user.js'
 import { addItem } from '../../data/items.js'
 import { dependents, loadDependents, initialized as depsInitialized } from '../../data/dependents.js'
-import { categories as categoryOptions, init, initialized as CatItemsInitialized } from '../../data/itemCategories'
+import { categories as categoryOptions, init, initialized as catItemsInitialized } from '../../data/itemCategories'
 import { formatDate } from '../../dates.js'
 import { Breadcrumb, Description, MoneyInput } from '../../components'
 import { goto } from '@roxi/routify'
@@ -42,7 +42,7 @@ onMount(async () => {
   if (! $depsInitialized && $user.policy_id) {
     loadDependents($user.policy_id)
   }
-  if (! $CatItemsInitialized) {
+  if (! $catItemsInitialized) {
     await init()
   }
 

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -46,7 +46,7 @@ onMount(async () => {
     await init()
   }
 
-  categories = $categoryOptions.length ? $categoryOptions : [{name: 'Electronics', id: 'f81291e9-6de0-4f7d-a98a-4d8bf86b520e'}] //TODO categoriesOptions isn't hydrating yet, remove mock data
+  categories = $categoryOptions.length ? $categoryOptions : [{name: 'Electronics', id: '63bcf980-e1f0-42d3-b2b0-2e4704159f4f'}] //TODO categoriesOptions isn't hydrating yet, remove mock data
 })
 
 const formatMonthOrDay = unit => unit.length === 1 ? `0${unit}` : unit

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -7,7 +7,6 @@ import { formatDate } from '../../dates.js'
 import { Breadcrumb, Description, MoneyInput } from '../../components'
 import { goto } from '@roxi/routify'
 import { Button, Form, Page, Select, TextArea, TextField } from '@silintl/ui-components'
-import { onMount } from 'svelte'
 
 const formData = {
   category: '',
@@ -37,17 +36,9 @@ let categories = []
 $: formData.coverage_start_date = `${year}-${formatMonthOrDay(month)}-${formatMonthOrDay(day)}` //api requires yyyy-mm-dd
 $: formData.purchase_date = formData.coverage_start_date
 $: accountablePersons = $dependents //TODO add current User to this: = [$dependents..., currentUser]
-
-onMount(async () => {
-  if (! $depsInitialized && $user.policy_id) {
-    loadDependents($user.policy_id)
-  }
-  if (! $catItemsInitialized) {
-    await init()
-  }
-
-  categories = $categoryOptions.length ? $categoryOptions : [{name: 'Electronics', id: '63bcf980-e1f0-42d3-b2b0-2e4704159f4f'}] //TODO categoriesOptions isn't hydrating yet, remove mock data
-})
+$: if ($catItemsInitialized) categories = $categoryOptions.length ? $categoryOptions : [{name: 'Electronics', id: '63bcf980-e1f0-42d3-b2b0-2e4704159f4f'}] //TODO categoriesOptions isn't hydrating yet, remove mock data
+$: ! $depsInitialized && $user.policy_id && loadDependents($user.policy_id)
+$: ! $catItemsInitialized && init()
 
 const formatMonthOrDay = unit => unit.length === 1 ? `0${unit}` : unit
 

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -59,8 +59,8 @@ const onSelectCategory = event => {
   formData.category = event.detail?.id
 }
 
-const onSubmit = () => {
-  addItem($user.policy_id, formData)
+const onSubmit = async () => {
+  await addItem($user.policy_id, formData)
 
   $goto('/home')
 }

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -1,53 +1,40 @@
 <script>
 import user from '../../authn/user.js'
 import { addItem } from '../../data/items.js'
+import { dependents, loadDependents, initialized as depsInitialized } from '../../data/dependents.js'
+import { categories as categoryOptions, init, initialized as CatItemsInitialized } from '../../data/itemCategories'
 import { Breadcrumb, Description, MoneyInput } from '../../components'
 import { goto } from '@roxi/routify'
 import { Button, Form, Page, Select, TextArea, TextField } from '@silintl/ui-components'
+import { onMount } from 'svelte'
 
 let formData = {
   category: '',
-  shortName: '',
+  country: '',
+  marketValueUSD: '',
+  coverage_start_date: '',  //TODO get data from somewhere or use purchase_date
+  coverage_status: '', //TODO get data from somewhere
   itemDescription: '',
-  uniqueIdentifier: '',
+  in_storage: false,  //TODO get data from somewhere
   make: '',
   model: '',
-  accountablePersonUuid: '',
-  accountablePersonName: '',
-  marketValueUSD: '',
+  shortName: '',
+  purchase_date: '',  //TODO get data from somewhere
+  uniqueIdentifier: '',
 }
 
-/* @todo Pull this from the database eventually: */
-let categoryOptions = [
-  {
-    "name": "Musical Instrument",
-    "id": "11111111-1111-4111-1111-111111111111",
-  },
-  {
-    "name": "Cell Phone",
-    "id": "22222222-2222-4222-2222-222222222222",
-  },
-]
+onMount(() => {
+  if($CatItemsInitialized === false) init()
 
-/** @todo Pull this from the API / backend */
-let accountablePersonOptions = [
-  {
-    name: 'Jeff Smith',
-    id: '11111111-1111-4111-1111-111111111111',
-  },
-  {
-    name: 'Sarah Smith',
-    id: '22222222-2222-4222-2222-222222222222',
-  },
-]
+  if($depsInitialized === false) loadDependents()
+})
 
 const onAccountablePersonChange = event => {
-  formData.accountablePersonUuid = event.detail.id
-  formData.accountablePersonName = event.detail.name
+  formData.country = event.detail.location
 }
 const onSubmit = event => {
   // TEMP
-  formData.category = categoryOptions.find(cat => cat.id === formData.category)
+  formData.category = $categoryOptions.find(cat => cat.id === formData.category)
   addItem($user.policy_id, formData)
   /* @todo Save this to the API / backend. */
   $goto('/home')
@@ -62,7 +49,7 @@ const saveForLater = () => {
   <Breadcrumb />
   <Form on:submit={onSubmit}>
     <p>
-      <Select label="Category" bind:selectedID={formData.category} options={categoryOptions} />
+      <Select label="Category" bind:selectedID={formData.category} options={$categoryOptions} />
     </p>
     <p>
       <TextField label="Short name" bind:value={formData.shortName}></TextField>
@@ -86,7 +73,7 @@ const saveForLater = () => {
     </p>
     <p>
       <Select label="Accountable person" on:change={onAccountablePersonChange}
-              options={accountablePersonOptions}></Select>
+              options={$dependents}></Select>
       <Description>
         Dependents are eligible. Dependents include spouses and children under 26 who haven't
         married or finished college. Coverage for children is limited to $3,000 per household.

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -3,7 +3,6 @@ import user from '../../authn/user.js'
 import { addItem } from '../../data/items.js'
 import { dependents, loadDependents, initialized as depsInitialized } from '../../data/dependents.js'
 import { categories as categoryOptions, init, initialized as catItemsInitialized } from '../../data/itemCategories'
-import { formatDate } from '../../dates.js'
 import { Breadcrumb, Description, MoneyInput } from '../../components'
 import { goto } from '@roxi/routify'
 import { Button, Form, Page, Select, TextArea, TextField } from '@silintl/ui-components'
@@ -23,24 +22,15 @@ const formData = {
   uniqueIdentifier: '',
 }
 
-const dateFormat = {
-  year: 'numeric',
-  month: 'numeric',
-  day: 'numeric'
-}
-  
-const [month, day, year] = formatDate(Date(), 'en-US', dateFormat).split('/')  //en-US to give consistent response
-
 let categories = []
+let today = new Date()
 
-$: formData.coverage_start_date = `${year}-${formatMonthOrDay(month)}-${formatMonthOrDay(day)}` //api requires yyyy-mm-dd
+$: formData.coverage_start_date = today.toISOString().slice(0, 10) //api requires yyyy-mm-dd
 $: formData.purchase_date = formData.coverage_start_date
 $: accountablePersons = $dependents //TODO add current User to this: = [$dependents..., currentUser]
 $: if ($catItemsInitialized) categories = $categoryOptions.length ? $categoryOptions : [{name: 'Electronics', id: '63bcf980-e1f0-42d3-b2b0-2e4704159f4f'}] //TODO categoriesOptions isn't hydrating yet, remove mock data
 $: ! $depsInitialized && $user.policy_id && loadDependents($user.policy_id)
 $: ! $catItemsInitialized && init()
-
-const formatMonthOrDay = unit => unit.length === 1 ? `0${unit}` : unit
 
 const onAccountablePersonChange = event => {
   formData.country = event.detail?.location //TODO handle when Dependents is empty, redirect to settings?

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -45,17 +45,20 @@ onMount(async () => {
     await init()
   }
 
-  categories = $categoryOptions.length ? $categoryOptions : [{name: 'Electronics', id: '123e4567-e89b-12d3-a456-426655440000'}] //TODO categoriesOptions isn't hydrating yet, remove mock data
+  categories = $categoryOptions.length ? $categoryOptions : [{name: 'Electronics', id: '1111-2222-3333-4444'}] //TODO categoriesOptions isn't hydrating yet, remove mock data
 })
 
 const formatMonthOrDay = unit => unit.length === 1 ? `0${unit}` : unit
 
 const onAccountablePersonChange = event => {
-  formData.country = event.detail.location || 'USA' //TODO handle when Dependents is empty, redirect to settings?
+  formData.country = event.detail?.location //TODO handle when Dependents is empty, redirect to settings?
 }
-const onSubmit = () => {
-  formData.category = categories.find(cat => cat.id === formData.category).id
 
+const onSelectCategory = event => {
+  formData.category = event.detail?.name
+}
+
+const onSubmit = () => {
   addItem($user.policy_id, formData)
 
   $goto('/home')
@@ -70,7 +73,7 @@ const saveForLater = () => {
   <Breadcrumb />
   <Form on:submit={onSubmit}>
     <p>
-      <Select label="Category" bind:selectedID={formData.category} options={categories} />
+      <Select label="Category" on:change={onSelectCategory} options={categories} />
     </p>
     <p>
       <TextField label="Short name" bind:value={formData.shortName}></TextField>

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -45,7 +45,7 @@ onMount(async () => {
     await init()
   }
 
-  categories = $categoryOptions.length ? $categoryOptions : [{name: 'Electronics', id: '1111-2222-3333-4444'}] //TODO categoriesOptions isn't hydrating yet, remove mock data
+  categories = $categoryOptions.length ? $categoryOptions : [{name: 'Electronics', id: 'f81291e9-6de0-4f7d-a98a-4d8bf86b520e'}] //TODO categoriesOptions isn't hydrating yet, remove mock data
 })
 
 const formatMonthOrDay = unit => unit.length === 1 ? `0${unit}` : unit
@@ -55,7 +55,7 @@ const onAccountablePersonChange = event => {
 }
 
 const onSelectCategory = event => {
-  formData.category = event.detail?.name
+  formData.category = event.detail?.id
 }
 
 const onSubmit = () => {

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -37,7 +37,7 @@ $: startDate = `${year}/${formatMonthOrDay(month)}/${formatMonthOrDay(day)}` //a
 onMount(() => {
   if($CatItemsInitialized === false) init()
 
-  if($depsInitialized === false) loadDependents()
+  if($depsInitialized === false && $user.policy_id) loadDependents($user.policy_id)
 })
 
 const formatMonthOrDay = unit => unit.length === 1 ? `0${unit}` : unit

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -36,6 +36,7 @@ let categories = []
 
 $: formData.coverage_start_date = `${year}-${formatMonthOrDay(month)}-${formatMonthOrDay(day)}` //api requires yyyy-mm-dd
 $: formData.purchase_date = formData.coverage_start_date
+$: accountablePersons = $dependents //TODO add current User to this: = [$dependents..., currentUser]
 
 onMount(async () => {
   if (! $depsInitialized && $user.policy_id) {
@@ -97,7 +98,7 @@ const saveForLater = () => {
     </p>
     <p>
       <Select label="Accountable person" on:change={onAccountablePersonChange}
-              options={$dependents}></Select>
+              options={accountablePersons}></Select>
       <Description>
         Dependents are eligible. Dependents include spouses and children under 26 who haven't
         married or finished college. Coverage for children is limited to $3,000 per household.

--- a/src/pages/items/new.svelte
+++ b/src/pages/items/new.svelte
@@ -3,17 +3,18 @@ import user from '../../authn/user.js'
 import { addItem } from '../../data/items.js'
 import { dependents, loadDependents, initialized as depsInitialized } from '../../data/dependents.js'
 import { categories as categoryOptions, init, initialized as CatItemsInitialized } from '../../data/itemCategories'
+import { formatDate } from '../../dates.js'
 import { Breadcrumb, Description, MoneyInput } from '../../components'
 import { goto } from '@roxi/routify'
 import { Button, Form, Page, Select, TextArea, TextField } from '@silintl/ui-components'
 import { onMount } from 'svelte'
 
-let formData = {
+const formData = {
   category: '',
   country: '',
   marketValueUSD: '',
-  coverage_start_date: '',  //TODO get data from somewhere or use purchase_date
-  coverage_status: '', //TODO get data from somewhere
+  coverage_start_date: startDate,
+  coverage_status: 'Draft',
   itemDescription: '',
   in_storage: false,  //TODO get data from somewhere
   make: '',
@@ -23,11 +24,23 @@ let formData = {
   uniqueIdentifier: '',
 }
 
+const dateFormat = {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric'
+}
+  
+const [day, month, year] = formatDate(Date(), 'en-US', dateFormat).split('/')  //en-US to give consistent response
+
+$: startDate = `${year}/${formatMonthOrDay(month)}/${formatMonthOrDay(day)}` //api requires yyyy-mm-dd
+
 onMount(() => {
   if($CatItemsInitialized === false) init()
 
   if($depsInitialized === false) loadDependents()
 })
+
+const formatMonthOrDay = unit => unit.length === 1 ? `0${unit}` : unit
 
 const onAccountablePersonChange = event => {
   formData.country = event.detail.location


### PR DESCRIPTION
- Parsed formdata to make the PolicyItemCreate api call. Example from console below
- brought in Dependants
- added dates/index.js for formatting dates
- refactored and added some mock data back in for non-hydrated api fields

```
category_id: "63bcf980-e1f0-42d3-b2b0-2e4704159f4f"
country: "USA"
coverage_amount: 123
coverage_start_date: "2021-08-17"
coverage_status: "Draft"
description: "iphone se"
in_storage: false
make: "se"
model: "iphone"
name: "se"
purchase_date: "2021-08-17"
serial_number: "123"
```

Note: still getting an error from the server:` debug_msg: "failed to close prepared statement: ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02): ERROR: insert or update on table \"items\" violates foreign key constraint \"items_category_id_fkey\" (SQLSTATE 23503)"`