### PR TITLE
Group dependents data by policy ID

### DIFF
--- a/src/data/dependents.js
+++ b/src/data/dependents.js
@@ -13,7 +13,8 @@ export const dependentsByPolicyId = writable({})
  * @return {Object}
  */
 export async function addDependent(policyId, depData) {
-  start(policyId)
+  const urlPath = `policies/${policyId}/dependents`
+  start(urlPath)
   
   let parsedDep = {
     name: depData.name,
@@ -22,7 +23,7 @@ export async function addDependent(policyId, depData) {
     child_birth_year: depData.childBirthYear && parseInt(depData.childBirthYear)
   }
   
-  const addedDependent = await CREATE(`policies/${policyId}/dependents`, parsedDep)
+  const addedDependent = await CREATE(urlPath, parsedDep)
   
   dependentsByPolicyId.update(data => {
     const dependents = data[policyId] || []
@@ -31,7 +32,7 @@ export async function addDependent(policyId, depData) {
     return data
   })
   
-  stop(policyId)
+  stop(urlPath)
   
   return addedDependent
 }
@@ -43,10 +44,11 @@ export async function addDependent(policyId, depData) {
  * @param {string} dependentId -- The UUID for the desired dependent
  */
 export async function deleteDependent(dependentId) {
-  start(dependentId)
+  const urlPath = `dependents/${dependentId}`
+  start(urlPath)
   
   // TODO: uncomment when endpoint is finished
-  // await DELETE(`dependents/${depId}`)
+  // await DELETE(urlPath)
   
   dependentsByPolicyId.update(data => {
     const dependents = data[policyId] || []
@@ -54,7 +56,7 @@ export async function deleteDependent(dependentId) {
     return data
   })
   
-  stop(dependentId)
+  stop(urlPath)
 }
 
 /**
@@ -66,7 +68,8 @@ export async function deleteDependent(dependentId) {
  * @param {Object} depData
  */
 export async function updateDependent(policyId, dependentId, depData) {
-  start(dependentId)
+  const urlPath = `dependents/${dependentId}`
+  start(urlPath)
   
   let parsedDep = {
     id: dependentId,
@@ -77,7 +80,7 @@ export async function updateDependent(policyId, dependentId, depData) {
   }
   
   // TODO: uncomment when endpoint is finished
-  // const updatedDependent = await UPDATE(`dependents/${dependentId}`)
+  // const updatedDependent = await UPDATE(urlPath)
   const updatedDependent = parsedDep // TEMP - until we can use API return value.
   
   dependentsByPolicyId.update(data => {
@@ -88,7 +91,7 @@ export async function updateDependent(policyId, dependentId, depData) {
     return data
   })
   
-  stop(dependentId)
+  stop(urlPath)
 }
 
 /**
@@ -98,13 +101,14 @@ export async function updateDependent(policyId, dependentId, depData) {
  * @export
  */
 export async function loadDependents(policyId) {
-  start(policyId)
+  const urlPath = `policies/${policyId}/dependents`
+  start(urlPath)
   
-  const loadedDependents = await GET(`policies/${policyId}/dependents`)
+  const loadedDependents = await GET(urlPath)
   dependentsByPolicyId.update(data => {
     data[policyId] = loadedDependents
     return data
   })
   
-  stop(policyId)
+  stop(urlPath)
 }

--- a/src/data/dependents.js
+++ b/src/data/dependents.js
@@ -41,9 +41,10 @@ export async function addDependent(policyId, depData) {
  *
  * @description a function to delete a dependent
  * @export
+ * @param {string} policyId -- The UUID for the applicable policy
  * @param {string} dependentId -- The UUID for the desired dependent
  */
-export async function deleteDependent(dependentId) {
+export async function deleteDependent(policyId, dependentId) {
   const urlPath = `dependents/${dependentId}`
   start(urlPath)
   

--- a/src/data/dependents.js
+++ b/src/data/dependents.js
@@ -10,7 +10,7 @@ export const initialized = writable(false)
  *
  * @description a function to create a dependent for a certain policy
  * @export
- * @param {string} policyId
+ * @param {string} policyId -- The UUID for the desired policy
  * @param {Object} depData
  * @return {Object} 
  */
@@ -40,8 +40,7 @@ export async function addDependent(policyId, depData) {
  *
  * @description a function to delete a dependent
  * @export
- * @param {Number} depId
- * @return {null} 
+ * @param {string} depId -- The UUID for the desired dependent
  */
 export async function deleteDependent(depId) {
     start(depId)
@@ -60,7 +59,7 @@ export async function deleteDependent(depId) {
  *
  * @description a function to update a dependent 
  * @export
- * @param {Number} depId
+ * @param {string} depId -- The UUID for the desired dependent
  * @param {Object} depData
  */
 export async function updateDependent(depId, depData) {
@@ -89,7 +88,7 @@ export async function updateDependent(depId, depData) {
 /**
  *
  * @description a function to load the dependents of a policy
- * @param {string} policyId
+ * @param {string} policyId -- The UUID for the desired policy
  * @export
  */
 export async function loadDependents(policyId) {

--- a/src/data/dependents.js
+++ b/src/data/dependents.js
@@ -39,33 +39,33 @@ export async function addDependent(policyId, depData) {
  *
  * @description a function to delete a dependent
  * @export
- * @param {string} depId -- The UUID for the desired dependent
+ * @param {string} dependentId -- The UUID for the desired dependent
  */
-export async function deleteDependent(depId) {
-    start(depId)
+export async function deleteDependent(dependentId) {
+    start(dependentId)
 
     // TODO: uncomment when endpoint is finished
     // await DELETE(`dependents/${depId}`)
 
     dependents.update(currDeps => {
-      return currDeps.filter(dep => dep.id !== depId)
+      return currDeps.filter(dep => dep.id !== dependentId)
     })
 
-    stop(depId)
+    stop(dependentId)
 }
 
 /**
  *
  * @description a function to update a dependent 
  * @export
- * @param {string} depId -- The UUID for the desired dependent
+ * @param {string} dependentId -- The UUID for the desired dependent
  * @param {Object} depData
  */
-export async function updateDependent(depId, depData) {
-  start(depId)
+export async function updateDependent(dependentId, depData) {
+  start(dependentId)
 
   let parsedDep = {
-    id: depId,
+    id: dependentId,
     name: depData.name,
     relationship: depData.relationship,
     location: depData.location,
@@ -73,15 +73,15 @@ export async function updateDependent(depId, depData) {
   }
 
   // TODO: uncomment when endpoint is finished
-  // let dpndt = await UPDATE(`dependents/${depId}`)
+  // let dpndt = await UPDATE(`dependents/${dependentId}`)
 
   dependents.update(currDeps => {
-    let i = currDeps.findIndex(dep => dep.id === depId)
+    let i = currDeps.findIndex(dep => dep.id === dependentId)
     currDeps[i] = parsedDep
     return currDeps
   })
 
-  stop(depId)
+  stop(dependentId)
 }
 
 /**

--- a/src/data/dependents.js
+++ b/src/data/dependents.js
@@ -1,5 +1,4 @@
 import { CREATE, GET } from "."
-import user from "../authn/user"
 import { writable } from "svelte/store"
 import { start, stop } from "../components/progress"
 

--- a/src/data/dependents.js
+++ b/src/data/dependents.js
@@ -11,29 +11,29 @@ export const initialized = writable(false)
  * @export
  * @param {string} policyId -- The UUID for the desired policy
  * @param {Object} depData
- * @return {Object} 
+ * @return {Object}
  */
 export async function addDependent(policyId, depData) {
-    start(policyId)
-
-    let parsedDep = {
-      name: depData.name,
-      relationship: depData.relationship,
-      location: depData.location,
-      child_birth_year: depData.childBirthYear && parseInt(depData.childBirthYear)
-    }
-
-    let dpndt = await CREATE(`policies/${policyId}/dependents`, parsedDep)
-
-    dependents.update(currDeps => {
-      currDeps.push(parsedDep)
-      return currDeps
-    })
-
-    stop(policyId)
-
-    return parsedDep
-} 
+  start(policyId)
+  
+  let parsedDep = {
+    name: depData.name,
+    relationship: depData.relationship,
+    location: depData.location,
+    child_birth_year: depData.childBirthYear && parseInt(depData.childBirthYear)
+  }
+  
+  let dpndt = await CREATE(`policies/${policyId}/dependents`, parsedDep)
+  
+  dependents.update(currDeps => {
+    currDeps.push(parsedDep)
+    return currDeps
+  })
+  
+  stop(policyId)
+  
+  return parsedDep
+}
 
 /**
  *
@@ -42,28 +42,28 @@ export async function addDependent(policyId, depData) {
  * @param {string} dependentId -- The UUID for the desired dependent
  */
 export async function deleteDependent(dependentId) {
-    start(dependentId)
-
-    // TODO: uncomment when endpoint is finished
-    // await DELETE(`dependents/${depId}`)
-
-    dependents.update(currDeps => {
-      return currDeps.filter(dep => dep.id !== dependentId)
-    })
-
-    stop(dependentId)
+  start(dependentId)
+  
+  // TODO: uncomment when endpoint is finished
+  // await DELETE(`dependents/${depId}`)
+  
+  dependents.update(currDeps => {
+    return currDeps.filter(dep => dep.id !== dependentId)
+  })
+  
+  stop(dependentId)
 }
 
 /**
  *
- * @description a function to update a dependent 
+ * @description a function to update a dependent
  * @export
  * @param {string} dependentId -- The UUID for the desired dependent
  * @param {Object} depData
  */
 export async function updateDependent(dependentId, depData) {
   start(dependentId)
-
+  
   let parsedDep = {
     id: dependentId,
     name: depData.name,
@@ -71,16 +71,16 @@ export async function updateDependent(dependentId, depData) {
     location: depData.location,
     child_birth_year: depData.childBirthYear
   }
-
+  
   // TODO: uncomment when endpoint is finished
   // let dpndt = await UPDATE(`dependents/${dependentId}`)
-
+  
   dependents.update(currDeps => {
     let i = currDeps.findIndex(dep => dep.id === dependentId)
     currDeps[i] = parsedDep
     return currDeps
   })
-
+  
   stop(dependentId)
 }
 
@@ -92,11 +92,11 @@ export async function updateDependent(dependentId, depData) {
  */
 export async function loadDependents(policyId) {
   start(policyId)
-
+  
   let dpndts = await GET(`policies/${policyId}/dependents`)
-
+  
   dependents.set(dpndts)
-
+  
   stop(policyId)
   initialized.set(true)
 }

--- a/src/data/dependents.js
+++ b/src/data/dependents.js
@@ -16,7 +16,7 @@ export async function addDependent(policyId, depData) {
   const urlPath = `policies/${policyId}/dependents`
   start(urlPath)
   
-  let parsedDep = {
+  const parsedDep = {
     name: depData.name,
     relationship: depData.relationship,
     location: depData.location,

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -6,20 +6,14 @@ import { loadMembersOfPolicy, membersByPolicyId } from '../../data/policy-member
 import { goto } from "@roxi/routify"
 import { Button, IconButton, Page } from "@silintl/ui-components"
 
-let householdMembers = []
 $: policyId = $user.policy_id
-
 $: if (policyId) {
   loadDependents(policyId)
   loadMembersOfPolicy(policyId)
 }
 
-$: haveLoadedPolicyMembers = $membersByPolicyId[policyId] !== undefined
-$: if (policyId && haveLoadedPolicyMembers) {
-  householdMembers = $membersByPolicyId[policyId]
-}
-
 $: dependents = $dependentsByPolicyId[policyId] || []
+$: householdMembers = $membersByPolicyId[policyId] || []
 
 const edit = id => $goto(`/household/settings/dependent/${id}`)
 const isYou = householdMember => householdMember.id === $user.id

--- a/src/pages/household/settings.svelte
+++ b/src/pages/household/settings.svelte
@@ -1,25 +1,25 @@
 <script>
 import user from '../../authn/user'
 import { Breadcrumb } from "../../components"
-import { dependents, initialized as haveLoadedDependents, loadDependents } from '../../data/dependents'
+import { dependentsByPolicyId, loadDependents } from '../../data/dependents'
 import { loadMembersOfPolicy, membersByPolicyId } from '../../data/policy-members'
 import { goto } from "@roxi/routify"
 import { Button, IconButton, Page } from "@silintl/ui-components"
 
 let householdMembers = []
+$: policyId = $user.policy_id
 
-$: if ($user.policy_id && !$haveLoadedDependents) {
-  loadDependents($user.policy_id)
+$: if (policyId) {
+  loadDependents(policyId)
+  loadMembersOfPolicy(policyId)
 }
 
-$: if ($user.policy_id) {
-  loadMembersOfPolicy($user.policy_id)
+$: haveLoadedPolicyMembers = $membersByPolicyId[policyId] !== undefined
+$: if (policyId && haveLoadedPolicyMembers) {
+  householdMembers = $membersByPolicyId[policyId]
 }
 
-$: haveLoadedPolicyMembers = $membersByPolicyId[$user.policy_id] !== undefined
-$: if ($user.policy_id && haveLoadedPolicyMembers) {
-  householdMembers = $membersByPolicyId[$user.policy_id]
-}
+$: dependents = $dependentsByPolicyId[policyId] || []
 
 const edit = id => $goto(`/household/settings/dependent/${id}`)
 const isYou = householdMember => householdMember.id === $user.id
@@ -73,7 +73,7 @@ const isYou = householdMember => householdMember.id === $user.id
 
   <h4>Dependents</h4>
   <ul class="accountable-people-list">
-    {#each $dependents as dependent}
+    {#each dependents as dependent}
       <li class="accountable-people-list-item">
         {dependent.name}
         <br />

--- a/src/pages/household/settings/dependent/[uuid].svelte
+++ b/src/pages/household/settings/dependent/[uuid].svelte
@@ -3,8 +3,7 @@ import user from '../../../../authn/user'
 import DependentForm from '../../../../components/DependentForm.svelte'
 import {
   deleteDependent,
-  dependents,
-  initialized,
+  dependentsByPolicyId,
   loadDependents,
   updateDependent
 } from '../../../../data/dependents'
@@ -13,8 +12,19 @@ import { Page } from '@silintl/ui-components'
 
 export let uuid
 
-$: $initialized || loadDependents($user.policy_id)
-$: dependent = $dependents.find(d => uuid && (d.id === uuid))
+let dependents = []
+$: policyId = $user.policy_id
+
+$: if (policyId) {
+  loadDependents(policyId)
+}
+
+$: haveLoadedPolicyDependents = $dependentsByPolicyId[policyId] !== undefined
+$: if (policyId && haveLoadedPolicyDependents) {
+  dependents = $dependentsByPolicyId[policyId]
+}
+
+$: dependent = dependents.find(d => uuid && (d.id === uuid))
 
 const onCancel = () => {
   $goto('../../settings')
@@ -26,7 +36,7 @@ const onRemove = async event => {
 }
 const onSubmit = async event => {
   const formData = event.detail
-  await updateDependent(formData.id, formData)
+  await updateDependent(policyId, formData.id, formData)
   $goto('../../settings')
 }
 </script>

--- a/src/pages/household/settings/dependent/[uuid].svelte
+++ b/src/pages/household/settings/dependent/[uuid].svelte
@@ -25,7 +25,7 @@ const onCancel = () => {
 }
 const onRemove = async event => {
   const dependentId = event.detail
-  await deleteDependent(dependentId)
+  await deleteDependent(policyId, dependentId)
   $goto('../../settings')
 }
 const onSubmit = async event => {

--- a/src/pages/household/settings/dependent/[uuid].svelte
+++ b/src/pages/household/settings/dependent/[uuid].svelte
@@ -12,18 +12,12 @@ import { Page } from '@silintl/ui-components'
 
 export let uuid
 
-let dependents = []
 $: policyId = $user.policy_id
-
 $: if (policyId) {
   loadDependents(policyId)
 }
 
-$: haveLoadedPolicyDependents = $dependentsByPolicyId[policyId] !== undefined
-$: if (policyId && haveLoadedPolicyDependents) {
-  dependents = $dependentsByPolicyId[policyId]
-}
-
+$: dependents = $dependentsByPolicyId[policyId] || []
 $: dependent = dependents.find(d => uuid && (d.id === uuid))
 
 const onCancel = () => {


### PR DESCRIPTION
### Changed
- Refactor dependents store to be grouped by policy ID
- Use API URL path as unique start/stop key for "dependent" data functions

### Fixed
- Remove unused import
- Update household settings page to use `$dependentsByPolicyId`
- Update edit-dependent page to use `$dependentsByPolicyId`